### PR TITLE
Update default endpoint in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Usage: app [OPTIONS]...
 Options:
   -v, --version                      output the version number
   -a, --addr <addr>                  An ethereum address
-  -e, --endpoint <endpoint>          An ethereum endpoint (default: "wss://ropsten-rpc.linkpool.io/ws")
+  -e, --endpoint <endpoint>          An ethereum endpoint (default: "http://mining.koinos.io")
   -t, --tip <percent>                The percentage of mined coins to tip the developers (default: "5")
   -p, --proof-period <seconds>       How often you want to submit a proof on average (default: "86400")
   -k, --key-file <file>              AES encrypted file containing private key


### PR DESCRIPTION
Seems like the default endpoint was updated, but it wasn't updated in readme https://github.com/open-orchard/koinos-miner/commit/078d530a5fb1bbe0b8ea6f4fe23181448dc4fee3#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL9