### PR TITLE
Use the difficulty from the miner rather than the target

### DIFF
--- a/miner/main.c
+++ b/miner/main.c
@@ -514,7 +514,7 @@ int main( int argc, char** argv )
             {
                work( &t_result, &secured_struct_hash, &t_nonce, word_buffer );
 
-               if( bignum_cmp( &t_result, &ss.target ) <= 0)
+               if( bignum_cmp( &t_result, &ss.target ) < 0)
                {
                   if( !words_are_unique( &secured_struct_hash, &t_nonce, word_buffer ) )
                   {

--- a/miner/main.c
+++ b/miner/main.c
@@ -558,11 +558,11 @@ int main( int argc, char** argv )
       }
       else
       {
+         bignum_inc( &result );
          bignum_to_string( &nonce, bn_str, sizeof(bn_str), false );
          bignum_to_string( &result, bn_str2, sizeof(bn_str2), false );
          fprintf( stdout, "N:%s;%s;\n", bn_str , bn_str2);
-
-         fprintf(stderr, "[C] Nonce: %s\n", bn_str);
+         fprintf(stderr, "[C] Nonce: %s; Difficulty: %s\n", bn_str, bn_str2);
          fflush(stderr);
       }
 

--- a/miner/main.c
+++ b/miner/main.c
@@ -341,6 +341,7 @@ int main( int argc, char** argv )
    struct bn seed, bn_i;
 
    char bn_str[78];
+   char bn_str2[78];
 
    SHA3_CTX c;
 
@@ -558,7 +559,8 @@ int main( int argc, char** argv )
       else
       {
          bignum_to_string( &nonce, bn_str, sizeof(bn_str), false );
-         fprintf( stdout, "N:%s;\n", bn_str );
+         bignum_to_string( &result, bn_str2, sizeof(bn_str2), false );
+         fprintf( stdout, "N:%s;%s;\n", bn_str , bn_str2);
 
          fprintf(stderr, "[C] Nonce: %s\n", bn_str);
          fflush(stderr);


### PR DESCRIPTION
The smart contract uses only the "target" to calculate the hash credits. Then "target" is the key to get more Koinos.
However, when the miner finds a nonce it is sending the initial target configured rather than the difficulty of the nonce (which can be better than the target).
This PR takes sends the difficulty of the nonce.