### PR TITLE
fix target comparison

### DIFF
--- a/miner/main.c
+++ b/miner/main.c
@@ -510,7 +510,7 @@ int main( int argc, char** argv )
             {
                work( &t_result, &secured_struct_hash, &t_nonce, word_buffer );
 
-               if( bignum_cmp( &t_result, &ss.target ) <= 0)
+               if( bignum_cmp( &t_result, &ss.target ) < 0)
                {
                   if( !words_are_unique( &secured_struct_hash, &t_nonce, word_buffer ) )
                   {


### PR DESCRIPTION
The smart contract accepts results that are [less than the target](https://github.com/koinos/koinos-erc20/blob/09199ada7201ff559d40cd24fd050e02230fe3a5/contracts/KnsTokenMining.sol#L134), but not equal.
```
   require( w[10] < target, "Work missed target" );
```